### PR TITLE
Prepend http protocol

### DIFF
--- a/pdf-service.js
+++ b/pdf-service.js
@@ -60,7 +60,7 @@ app.post('/from-html', async (req, res) => {
 
 app.get('/from-url', async (req, res) => {
     calls.fromUrl++;
-    const url = withHttp(req.query.url);
+    let url = req.query.url;
     console.log('/from-url');
 
     if (!url) {
@@ -71,7 +71,7 @@ app.get('/from-url', async (req, res) => {
 
     let pdfFilePath;
     try {
-        pdfFilePath = await generatePdf(url, req.query.media);
+        pdfFilePath = await generatePdf(withHttp(url), req.query.media);
 
         deliverPdfFile(res, pdfFilePath);
     } catch (err) {
@@ -83,10 +83,6 @@ app.get('/from-url', async (req, res) => {
 });
 
 function withHttp (url) {
-    if (!url) {
-        return;
-    }
-
     return !/^https?:\/\//i.test(url)
         ? `http://${url}`
         : url;

--- a/pdf-service.js
+++ b/pdf-service.js
@@ -60,7 +60,7 @@ app.post('/from-html', async (req, res) => {
 
 app.get('/from-url', async (req, res) => {
     calls.fromUrl++;
-    const url = req.query.url;
+    const url = withHttp(req.query.url);
     console.log('/from-url');
 
     if (!url) {
@@ -81,6 +81,16 @@ app.get('/from-url', async (req, res) => {
         deliverJson(res, {msg, err}, 500);
     }
 });
+
+function withHttp (url) {
+    if (!url) {
+        return;
+    }
+
+    return !/^https?:\/\//i.test(url)
+        ? `http://${url}`
+        : url;
+}
 
 function deliverJson(res, resp, status = 200) {
     res.status(status).contentType('json').send(resp);


### PR DESCRIPTION
#8 It's not possible to convert using from-url without protocol http(s)

Added function to check if the URL has HTTP protocol and prepend it.