### PR TITLE
Add compression by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kooldev/puppeteer:latest
+FROM kooldev/puppeteer:1.0
 
 WORKDIR /app
 COPY --chown=pptruser:pptruser . /app


### PR DESCRIPTION
Leveraging https://github.com/kool-dev/docker-puppeteer/commit/5eb151e4931156f5647c9956a48239aa7190e2fb - shrinkpdf with ghostscript.

This has already been build and pushed as `1.2.0`; will be default as `1.0` once we merge and tag/release.